### PR TITLE
Support for multi-touch zooming

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -6,7 +6,7 @@ import MapInteraction from 'react-map-interaction';
 class App extends Component {
   render() {
     return (
-      <MapInteraction>
+      <MapInteraction minScale={.05} maxScale={5} debug>
         <img src="/grid.png" style={{ pointerEvents: 'none' }} alt="" />
       </MapInteraction>
     );


### PR DESCRIPTION
Changes:
- Pinch to zoom now works on mobile
- There is a debug mode which draws various info to the screen: `<MapInteraction debug />`

The interaction is not as smooth as I would like it, however.  For example, if you have two fingers down and drag, such that the distance between the fingers remains the same, this should actually pan the object.

To test, fire up the example-app and point your mobile device to your machine. Or, use the iOS simulator on mac (you can open Safari to get a developer console for the simulator).