### PR TITLE
Move React to a Peer Dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "prop-types": ">=15.0",
+    "prop-types": ">=15.0"
+  },
+  "peerDependencies": {
     "react": ">=0.14"
   },
   "devDependencies": {


### PR DESCRIPTION
Making React a peer dependency will ensure that only a single copy of React is installed: https://yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies