### PR TITLE
Allow parent to control the scale and translation by exposing 'scale', 'translation', and 'onChange' props

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm install --save react-map-interaction
 
 ## Examples
 
+### Basic
 ```js
 import { MapInteractionCSS } from 'react-map-interaction';
 
@@ -25,11 +26,12 @@ const ThingMap = () => {
 }
 ```
 
+### Usage without CSS
 ```js
 import { MapInteraction } from 'react-map-interaction';
 
 // Use MapInteraction if you want to determine how to use the resulting translation.
-const ImInControl = () => {
+const NotUsingCSS = () => {
   <MapInteraction>
     {
       ({ translation, scale }) => { /* Use the passed values to scale content on your own. */ }
@@ -38,12 +40,51 @@ const ImInControl = () => {
 }
 ```
 
+### Controlled
+```js
+import { MapInteractionCSS } from 'react-map-interaction';
+
+// If you want to have control over the scale and translation,
+// then use the `scale`, `translation`, and `onChange` props.
+class Controlled extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      scale: 1,
+      translation: { x: 0, y: 0 }
+    };
+  }
+
+  render() {
+    const { scale, translation } = this.state;
+    return (
+      <MapInteractionCSS
+        scale={scale}
+        translation={translation}
+        onChange={({ scale, translation }) => this.setState({ scale, translation })}
+      >
+        <img src="path/to/thing.png" />
+      </MapInteractionCSS>
+    );
+  }
+}
+```
+
 ## Prop Types for MapInteractionCSS (all optional)
+MapInteraction doesn't require any props. It will control its own internal state, and pass values to its children. If you need to control the scale and translation then you can pass those values as props and listen to the onChange event to receive updates.
 ```js
 {
-  // Initial x/y coordinates
-  initialX: PropTypes.number,
-  initialY: PropTypes.number,
+  // The scale applied to the dimensions of the contents. A scale of 1 means the
+  // contents appear at actual size, greater than 1 is zoomed, and between 0 and 1 is shrunken.
+  scale: PropTypes.number,
+  defaultScale: PropTypes.number,
+
+  // The distance in pixels to translate the contents by.
+  translation: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
+  defaultTranslation: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
+
+  // Called with an object { scale, translation }
+  onChange: PropTypes.func,
 
   // The min and max of the scale of the zoom. Must be > 0.
   minScale: PropTypes.number,

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -4,6 +4,14 @@ import React, { Component } from 'react';
 import { MapInteractionCSS } from 'react-map-interaction';
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      scale: 1,
+      translation: { x: 0, y: 0 }
+    };
+  }
+
   render() {
     // set container node at an origin other than client 0,0 to make sure we handle this case
     const offset = 20;
@@ -16,9 +24,19 @@ class App extends Component {
       height: `calc(100vh - ${offset}px)`
     }
 
+    const { scale, translation } = this.state;
     return (
       <div style={style}>
-        <MapInteractionCSS minScale={.05} maxScale={5} showControls>
+        <MapInteractionCSS
+          scale={scale}
+          translation={translation}
+          onChange={({ scale, translation }) => this.setState({ scale, translation })}
+          defaultScale={1}
+          defaultTranslation={{ x: 0, y: 0 }}
+          minScale={0.05}
+          maxScale={5}
+          showControls
+        >
           <div style={{ position: 'relative' }}>
             <div style={{ position: 'absolute', left: 30, top: 30 }}>
               <button


### PR DESCRIPTION
This diff gives you the ability to have MapInteraction behave more like a controlled component. You can dictate the `scale` and `translation` by passing them as props. I have updated the README as well as the example app to show how it works. The purpose of this is to give the parent optional control over the scale/translation values, rather than be at the mercy of the component's internal state.

This will be helpful if you need to do something like render two MapInteraction components to the screen side by side and keep their scale/translation in sync.

This introduces one breaking change: initialX and initialY are no longer supported props. You must use scale/defaultScale and translation/defaultTranslation to achieve control.