### PR TITLE
Add feature for passing min and max translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ MapInteraction doesn't require any props. It will control its own internal state
   translation: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
   defaultTranslation: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
 
+  // Apply a limit to the translation in any direction in pixel values. The default is unbounded.
+  translationBounds: PropTypes.shape({
+    xMin: PropTypes.number, xMax: PropTypes.number, yMin: PropTypes.number, yMax: PropTypes.number
+  }),
+
   // Called with an object { scale, translation }
   onChange: PropTypes.func,
 


### PR DESCRIPTION
Fixes #8 
Fixes #13 

This diff adds a new property `translationBounds` which allows the parent to define boundaries for the translation in pixel values.

To test this diff, add `translationBounds` in the example App.js.