### PR TITLE
Fix issue where zoom on mobile didnt scale properly

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -297,7 +297,9 @@ class MapInteraction extends Component {
     const dist0       = touchDistance(startTouches[0], startTouches[1]);
     const dist1       = touchDistance(newTouches[0], newTouches[1]);
     const scaleChange = dist1 / dist0;
-    const targetScale = this.startPointerInfo.scale + (scaleChange - 1);
+
+    const startScale  = this.startPointerInfo.scale;
+    const targetScale = startScale + ((scaleChange - 1) * startScale);
     const newScale    = clamp(this.props.minScale, targetScale, this.props.maxScale);
 
     // calculate mid points
@@ -309,7 +311,7 @@ class MapInteraction extends Component {
       y: newMidPoint.y - startMidpoint.y
     };
 
-    const scaleRatio = newScale / this.startPointerInfo.scale;
+    const scaleRatio = newScale / startScale;
 
     const focalPt = this.clientPosToTranslatedPos(startMidpoint, this.startPointerInfo.translation);
     const focalPtDelta = {


### PR DESCRIPTION
This resolves #16 
The issue is that we were calculating the new scale during a pinch/zoom without taking into consideration the original scale. This means that a pinch/zoom would work fine if the original scale were 1. However, if the original scale were anything else, we were not properly calculating the updated scale. Note the addition of the `* startScale`, which is what now takes that original scale into consideration.

Below is a screencast of it now working. Compare to the gif in #16 for comparison.
![pinch-working-now](https://user-images.githubusercontent.com/3643611/42056821-55850112-7ad0-11e8-9e50-35e21d8b5a96.gif)
