### PR TITLE
Fix typo that caused us to only use x dimension to calculate distance

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -22,7 +22,7 @@ const eventNames = () => {
 const distance = (p1, p2) => {
   const dx = p1.x - p2.x;
   const dy = p1.y - p2.y;
-  return Math.sqrt(Math.pow(dx, 2), Math.pow(dy, 2));
+  return Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));
 }
 
 const midpoint = (p1, p2) => {


### PR DESCRIPTION
This was just a bad typo that went over looked. This is supposed to be a simple hypotenuse calculation using c^2 = a^2 + b^2. However, instead of the `+` above we had a `,`. 