### PR TITLE
Add type=button

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -510,6 +510,7 @@ class Controls extends Component {
               btnClass ? btnClass : '',
               plusBtnClass ? plusBtnClass : '',
             ].join(' ')}
+            type="button"
             style={(btnClass || plusBtnClass) ? undefined : btnStyle}
             disabled={scale >= maxScale}
           >
@@ -523,6 +524,7 @@ class Controls extends Component {
               btnClass ? btnClass : '',
               minusBtnClass ? minusBtnClass : '',
             ].join(' ')}
+            type="button"
             style={(btnClass || minusBtnClass) ? undefined : btnStyle}
             disabled={scale <= minScale}
           >


### PR DESCRIPTION
Describe:

Once add this in a form, <button> without type attribute might be treated as a submit button, which cause a form submission once click the zoom-in and zoom-out button.  