### PR TITLE
This diff fixes 2 issues, both were bugs related to dragging.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+# Unreleased
+
+## Fix issue of contents changing translation when dragging outside of container.
+This bug can be reproduced by a) Perform a normal drag inside of the container, then b) Drag somewhere outside of the container, which should have no impact on the translation of the contents, however you will see that the contents will change translation.
+
+## Fix #20. 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -20,8 +20,9 @@ class App extends Component {
       position: 'absolute',
       top: offset,
       left: offset,
-      width: `calc(100vw - ${offset}px)`,
-      height: `calc(100vh - ${offset}px)`
+      width: `calc(80vw - ${offset}px)`,
+      height: `calc(50vh - ${offset}px)`,
+      border: '1px solid blue'
     }
 
     const { scale, translation } = this.state;


### PR DESCRIPTION
The first change an issue where the map was changing translation when dragging outside of container.
This bug can be reproduced by:
- Perform a normal drag inside of the container, then
- Drag somewhere outside of the container, which should have no impact on the translation of the contents, however you will see that the contents will change translation.
This was happening because the touchEnd event handler of the initial drag was not being called because we were improperly doing a stopPropagation that blocked it. Now, the touchEnd event is attached at the window and triggered during the 'capture' phase of the event, ensuring that it will get called *before* any other handlers have a chance to stop prop.

The second change fixes #20.
The change here was simply to make startPointerInfo undefined whenever `pointers` was empty, instead of having startPointerInfo defined with an empty pointers list.

Also fixes #28 by adding a changelog.