### PR TITLE
Only trigger preventDefault if drag is greater than 1

### DIFF
--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -220,9 +220,11 @@ class MapInteraction extends Component {
       y: translation.y + dragY
     };
 
+    const shouldPreventTouchEndDefault = Math.abs(dragX) > 1 || Math.abs(dragY) > 1;
+
     this.setState({
       translation: this.clampTranslation(newTranslation),
-      shouldPreventTouchEndDefault: true
+      shouldPreventTouchEndDefault
     }, () => this.updateParent());
   }
 


### PR DESCRIPTION
Relating to #37, adds an optional threshold prop and changes the `preventDefault` mechanism to only trigger when the drag is larger or equal to the threshold. 