### PR TITLE
breaking: React 17 compatibility and API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ MapInteraction doesn't require any props. It will control its own internal state
 
 ## Development
 Please feel free to file issues or put up a PR.
+Note the node version in .nvmrc file.
 
 ```
 $ yarn install

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Add map like zooming and panning to any React element. This works on both touch 
 npm install --save react-map-interaction
 ```
 
-## Examples
-
-We use [storybook](https://storybook.js.org/) in development, and you can pull this repo and run storybook with `npm run storybook`. See files with `*.stories.*` for examples.
+## Usage
 
 ### Basic
 ```js
@@ -54,8 +52,10 @@ class Controlled extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      scale: 1,
-      translation: { x: 0, y: 0 }
+      value: {
+        scale: 1,
+        translation: { x: 0, y: 0 }
+      }
     };
   }
 
@@ -63,9 +63,8 @@ class Controlled extends Component {
     const { scale, translation } = this.state;
     return (
       <MapInteractionCSS
-        scale={scale}
-        translation={translation}
-        onChange={({ scale, translation }) => this.setState({ scale, translation })}
+        value={this.state.value}
+        onChange={(value) => this.setState({ value })}
       >
         <img src="path/to/thing.png" />
       </MapInteractionCSS>
@@ -74,6 +73,13 @@ class Controlled extends Component {
 }
 ```
 
+### Controlled vs Uncontrolled
+Similar to React's `<input />` component, you can either control the state of MapInteraction
+yourself, or let it handle that for you. It is not recommended, however, that you change
+this mode of control during the lifecycle of a component. Once you have started controlling
+the state, keep controlling it under you unmount MapInteraction (likewise with uncontrolled).
+If you pass `value` prop, we assume you are controlling the state via a `onChange` prop.
+
 ### Click and drag handlers on child elements
 This component lets you decide how to respond to click/drag events on the children that you render inside of the map. To know if an element was clicked or dragged, you can attach onClick or onTouchEnd events and then check the `e.defaultPrevented` attribute. MapInteraction will set `defaultPrevented` to `true` if the touchend/mouseup event happened after a drag, and false if it was a click. See `index.stories.js` for an example.
 
@@ -81,17 +87,21 @@ This component lets you decide how to respond to click/drag events on the childr
 MapInteraction doesn't require any props. It will control its own internal state, and pass values to its children. If you need to control the scale and translation then you can pass those values as props and listen to the onChange event to receive updates.
 ```js
 {
-  // The scale applied to the dimensions of the contents. A scale of 1 means the
-  // contents appear at actual size, greater than 1 is zoomed, and between 0 and 1 is shrunken.
-  scale: PropTypes.number,
-  defaultScale: PropTypes.number,
+  value: PropTypes.shape({
+    // The scale applied to the dimensions of the contents. A scale of 1 means the
+    // contents appear at actual size, greater than 1 is zoomed, and between 0 and 1 is shrunken.
+    scale: PropTypes.number,
+    // The distance in pixels to translate the contents by.
+    translation: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),    
+  }),
+
+  defaultValue: PropTypes.shape({
+    scale: PropTypes.number,
+    translation: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
+  }),
+
   // Stops user from being able to zoom, but will still adhere to props.scale
   disableZoom: PropTypes.bool,
-
-
-  // The distance in pixels to translate the contents by.
-  translation: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
-  defaultTranslation: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
 
   // Stops user from being able to pan. Note that translation can still be
   // changed via zooming, in order to keep the focal point beneath the cursor. This prop does not change the behavior of the `translation` prop.
@@ -143,4 +153,16 @@ MapInteraction doesn't require any props. It will control its own internal state
 ```
 
 ## Development
-Please feel free to file issues or put up a PR. There are currently no automated tests, but there is an example application in the `example` directory. When you build this library it will inject the dist into the `example/node_modules` so it can be imported by that application. Re-run `npm run start` when you make changes to the lib (create-react-app doesn't watch node modules).
+Please feel free to file issues or put up a PR.
+
+```
+$ yarn install
+```
+
+```
+$ yarn test
+```
+
+```
+$ yarn run storybook
+```

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+BREAKING: To make compatible with React 17, we got rid of componentWillReceiveProps usage. In doing so,
+we also took the time to simplify the API to MapInteraction to just require `value` and `onChange` when
+you want to control the component, instead of `scale`, `translation`, and `onChange`. The minimum React
+peer dependency is now 16.3.
+
 # 1.3.1
 
 ### Fix issue of contents changing translation when dragging outside of container.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-map-interaction",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "description": "'Add map like zooming and dragging to any element'",
   "main": "dist/react-map-interaction.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.14",
+    "react": ">=16.3",
     "prop-types": ">=15.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=16.3",
-    "prop-types": ">=15.0"
+    "react": "^16.3.0",
+    "prop-types": "^15.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -504,10 +504,7 @@ class MapInteractionController extends Component {
     */
     if (!wasControlled && nowControlled) {
       return {
-        value: {
-          scale: undefined,
-          translation: undefined
-        },
+        value: undefined,
         lastKnownValueFromProps: props.value
       };
     } else if (wasControlled && !nowControlled) {
@@ -533,6 +530,11 @@ class MapInteractionController extends Component {
   innerProps() {
     const { value, defaultValue, onChange, ...innerProps } = this.props;
     return innerProps;
+  }
+
+  getValue() {
+    const controlled = MapInteractionController.isControlled(this.props);
+    return controlled ? this.props.value : this.state.value;
   }
 
   render() {

--- a/src/MapInteraction.test.jsx
+++ b/src/MapInteraction.test.jsx
@@ -151,49 +151,78 @@ describe("MapInteraction", () => {
         this.state = { value: { scale: 1, translation: { x: 0, y: 0 } } };
       }
 
+      takeControl(callback) {
+        this.setState({
+          value: this.ref.getValue()
+        }, callback);
+      }
+
       render() {
         return (
           <MapInteraction
+            ref={(node) => { this.ref = node; }}
             value={this.state.value}
             onChange={(value) => {
-              const promise = new Promise((resolve) => {
-                this.setState({ value }, resolve);
-              });
-              this.props.onSetState(promise);
+              this.setState({ value });
             }}
           />
         );
       }
     }
 
-    let setStatePromise;
-
     refStub = mockContainerRef();
-    wrapper = mount(<Controller onSetState={(p) => { setStatePromise = p }} />);
-    const controller = wrapper.find(Controller);
-    const rmi = wrapper.find(MapInteraction);
-    const rmiInner = rmi.find(MapInteractionControlled);
-
-    // initial state
-    expect(controller.state().value.scale).to.equal(1);
-    expect(rmi.props().value.scale).to.equal(1);
-    expect(rmiInner.props().value.scale).to.equal(1);
-
-    // switch to uncontrolled then back again
-    controller.instance().setState({ value: undefined });
-    controller.instance().setState({ value: { scale: 2 , translation: { x: 0, y: 0 } } });
-
-    rmiInner.instance().changeScale(1);
-
-    return setStatePromise.then(() => {
+    wrapper = mount(<Controller />);
+    const getComponents = () => {
       wrapper.update();
       const controller = wrapper.find(Controller);
       const rmi = wrapper.find(MapInteraction);
       const rmiInner = rmi.find(MapInteractionControlled);
+      return { controller, rmi, rmiInner };
+    }
 
-      expect(controller.state().value.scale).to.equal(3);
-      expect(rmi.props().value.scale).to.equal(3);
-      expect(rmiInner.props().value.scale).to.equal(3);
+    let { controller, rmi, rmiInner } = getComponents();
+    // Check initial state
+    expect(controller.state().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+    expect(rmi.props().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+    expect(rmiInner.props().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+
+    // switch to uncontrolled and check that the map interaction has source of truth
+    const promiseToUncontrolled = new Promise((resolve) => {
+      controller.instance().setState({ value: undefined }, resolve);
+    }).then(() => {
+      let { controller, rmi, rmiInner } = getComponents();
+      expect(controller.state().value).to.equal(undefined);
+      expect(rmi.state().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+      expect(rmi.props().value).to.equal(undefined);
+      expect(rmiInner.props().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+    });
+
+    // switch back to controlled and check that the controller now has the source of truth
+    const promiseToControlled = promiseToUncontrolled.then(() => {
+      return new Promise((resolve) => {
+        controller.instance().takeControl(resolve);
+      });
+    });
+    promiseToControlled.then(() => {
+      let { controller, rmi, rmiInner } = getComponents();
+      expect(controller.state().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+      expect(rmi.props().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+      expect(rmi.state().value).to.equal(undefined);
+      expect(rmiInner.props().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+    });
+
+    // switch back to uncontrolled one more time
+    const promiseToUncontrolled2 = promiseToControlled.then(() => {
+      new Promise((resolve) => {
+        controller.instance().setState({ value: undefined }, resolve);
+      });
+    })
+    return promiseToUncontrolled2.then(() => {
+      let { controller, rmi, rmiInner } = getComponents();
+      expect(controller.state().value).to.equal(undefined);
+      expect(rmi.state().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
+      expect(rmi.props().value).to.equal(undefined);
+      expect(rmiInner.props().value).to.deep.equal({ scale: 1, translation: { x: 0, y: 0 } });
     });
   });
 });

--- a/src/MapInteraction.test.jsx
+++ b/src/MapInteraction.test.jsx
@@ -127,11 +127,14 @@ describe("MapInteraction", () => {
       expect(controller.state().scale).to.equal(2);
       expect(rmi.props().scale).to.equal(2);
       expect(rmiInner.props().scale).to.equal(2);
-    })
+    });
   });
 
   // This is an unhappy path. The caller of RMI should not switch from
-  // controlled to uncontrolled.
+  // controlled to uncontrolled. We just want to make sure we dont blow up.
+  // The caller should be able to switch from controlled-uncontrolled-controlled
+  // and have the component work back in a fully controlled state, but
+  // it wont work while in the intermediary uncontrolled state.
   it("parent switches from controlled to uncontrolled", () => {
     class Controller extends Component {
       constructor(props) {
@@ -168,6 +171,21 @@ describe("MapInteraction", () => {
     expect(rmi.props().scale).to.equal(1);
     expect(rmiInner.props().scale).to.equal(1);
 
+    // switched to uncontrolled then back again
     controller.instance().setState({ scale: undefined });
+    controller.instance().setState({ scale: 2 });
+
+    rmiInner.instance().changeScale(1);
+
+    return setStatePromise.then(() => {
+      wrapper.update();
+      const controller = wrapper.find(Controller);
+      const rmi = wrapper.find(MapInteraction);
+      const rmiInner = rmi.find(MapInteractionControlled);
+
+      expect(controller.state().scale).to.equal(3);
+      expect(rmi.props().scale).to.equal(3);
+      expect(rmiInner.props().scale).to.equal(3);
+    });
   });
 });

--- a/src/MapInteraction.test.jsx
+++ b/src/MapInteraction.test.jsx
@@ -37,10 +37,16 @@ describe("MapInteraction", () => {
     expect(!isNaN(translation.y)).to.equal(true);
   });
 
-  it("full mount - uses default props", () => {
+  it("full mount, controlled", () => {
     const childrenCallback = sinon.fake();
     wrapper = mount(
-      <MapInteraction translation={{ x: 100, y: 105 }} scale={3} onChange={() => {}}>
+      <MapInteraction
+        value={{
+          translation: { x: 100, y: 105 },
+          scale: 3
+        }}
+        onChange={() => {}}
+      >
         {childrenCallback}
       </MapInteraction>
     );
@@ -54,8 +60,10 @@ describe("MapInteraction", () => {
     const changeCb = sinon.fake();
     wrapper = mount(
       <MapInteraction
-        translation={{ x: 100, y: 105 }}
-        scale={3}
+        value={{
+          translation: { x: 100, y: 105 },
+          scale: 3
+        }}
         onChange={changeCb}
       />
     );
@@ -70,31 +78,32 @@ describe("MapInteraction", () => {
     refStub = mockContainerRef();
     wrapper = mount(
       <MapInteraction
-        defaultTranslation={{ x: 100, y: 105 }}
-        defaultScale={3}
+        defaultValue={{
+          translation: { x: 100, y: 105 },
+          scale: 3
+        }}
       />
     );
-    expect(wrapper.state().scale).to.equal(3);
+    expect(wrapper.state().value.scale).to.equal(3);
     const instance = wrapper.find(MapInteractionControlled).instance();
     instance.changeScale(-1);
-    expect(wrapper.state().scale).to.equal(2);
+    expect(wrapper.state().value.scale).to.equal(2);
   });
 
   it("fully controlled with changeScale called", () => {
     class Controller extends Component {
       constructor(props) {
         super(props);
-        this.state = { scale: 1, translation: { x: 0, y: 0 }};
+        this.state = { value: { scale: 1, translation: { x: 0, y: 0 } }};
       }
 
       render() {
         return (
           <MapInteraction
-            translation={this.state.translation}
-            scale={this.state.scale}
+            value={this.state.value}
             onChange={(params) => {
               const promise = new Promise((resolve) => {
-                this.setState(params, resolve);
+                this.setState({ value: params }, resolve);
               });
               this.props.onSetState(promise);
             }}
@@ -112,9 +121,9 @@ describe("MapInteraction", () => {
     const rmiInner = rmi.find(MapInteractionControlled);
 
     // initial state
-    expect(controller.state().scale).to.equal(1);
-    expect(rmi.props().scale).to.equal(1);
-    expect(rmiInner.props().scale).to.equal(1);
+    expect(controller.state().value.scale).to.equal(1);
+    expect(rmi.props().value.scale).to.equal(1);
+    expect(rmiInner.props().value.scale).to.equal(1);
 
     rmiInner.instance().changeScale(1);
 
@@ -124,9 +133,9 @@ describe("MapInteraction", () => {
       const rmi = wrapper.find(MapInteraction);
       const rmiInner = rmi.find(MapInteractionControlled);
 
-      expect(controller.state().scale).to.equal(2);
-      expect(rmi.props().scale).to.equal(2);
-      expect(rmiInner.props().scale).to.equal(2);
+      expect(controller.state().value.scale).to.equal(2);
+      expect(rmi.props().value.scale).to.equal(2);
+      expect(rmiInner.props().value.scale).to.equal(2);
     });
   });
 
@@ -139,17 +148,16 @@ describe("MapInteraction", () => {
     class Controller extends Component {
       constructor(props) {
         super(props);
-        this.state = { scale: 1, translation: { x: 0, y: 0 }};
+        this.state = { value: { scale: 1, translation: { x: 0, y: 0 } } };
       }
 
       render() {
         return (
           <MapInteraction
-            translation={this.state.translation}
-            scale={this.state.scale}
-            onChange={(params) => {
+            value={this.state.value}
+            onChange={(value) => {
               const promise = new Promise((resolve) => {
-                this.setState(params, resolve);
+                this.setState({ value }, resolve);
               });
               this.props.onSetState(promise);
             }}
@@ -167,13 +175,13 @@ describe("MapInteraction", () => {
     const rmiInner = rmi.find(MapInteractionControlled);
 
     // initial state
-    expect(controller.state().scale).to.equal(1);
-    expect(rmi.props().scale).to.equal(1);
-    expect(rmiInner.props().scale).to.equal(1);
+    expect(controller.state().value.scale).to.equal(1);
+    expect(rmi.props().value.scale).to.equal(1);
+    expect(rmiInner.props().value.scale).to.equal(1);
 
-    // switched to uncontrolled then back again
-    controller.instance().setState({ scale: undefined });
-    controller.instance().setState({ scale: 2 });
+    // switch to uncontrolled then back again
+    controller.instance().setState({ value: undefined });
+    controller.instance().setState({ value: { scale: 2 , translation: { x: 0, y: 0 } } });
 
     rmiInner.instance().changeScale(1);
 
@@ -183,9 +191,9 @@ describe("MapInteraction", () => {
       const rmi = wrapper.find(MapInteraction);
       const rmiInner = rmi.find(MapInteractionControlled);
 
-      expect(controller.state().scale).to.equal(3);
-      expect(rmi.props().scale).to.equal(3);
-      expect(rmiInner.props().scale).to.equal(3);
+      expect(controller.state().value.scale).to.equal(3);
+      expect(rmi.props().value.scale).to.equal(3);
+      expect(rmiInner.props().value.scale).to.equal(3);
     });
   });
 });

--- a/src/TestUtil.js
+++ b/src/TestUtil.js
@@ -1,11 +1,11 @@
 import sinon from 'sinon';
 
-import MapInteraction from './MapInteraction';
+import {MapInteractionControlled} from './MapInteraction';
 
 // mock the containerNode ref since it wont get set in a shallow render
 // this is required if your test needs to simulate dom events
 function mockContainerRef() {
-  return sinon.stub(MapInteraction.prototype, 'getContainerNode')
+  return sinon.stub(MapInteractionControlled.prototype, 'getContainerNode')
     .callsFake(() => {
       // _TODO_ new Element() possible?
       return {
@@ -22,7 +22,7 @@ function mockContainerRef() {
 // event listeners but still need to mock the client rect, which
 // jsdom mocks but with 0s as default values.
 function mockClientRect() {
-  return sinon.stub(MapInteraction.prototype, 'getContainerBoundingClientRect')
+  return sinon.stub(MapInteractionControlled.prototype, 'getContainerBoundingClientRect')
     .callsFake(() => {
       return { left: 0, width: 200, top: 0, height: 200 };
     });

--- a/src/TestUtil.js
+++ b/src/TestUtil.js
@@ -7,7 +7,6 @@ import {MapInteractionControlled} from './MapInteraction';
 function mockContainerRef() {
   return sinon.stub(MapInteractionControlled.prototype, 'getContainerNode')
     .callsFake(() => {
-      // _TODO_ new Element() possible?
       return {
         addEventListener: function() {},
         removeEventListener: function() {},

--- a/src/UseCases.test.jsx
+++ b/src/UseCases.test.jsx
@@ -85,11 +85,12 @@ function makeWheelEvent(deltaY = 1) {
   return evt;
 }
 
-// Utility for mounting an RMI instance and gettinb back some useful
+// Utility for mounting an RMI instance and getting back some useful
 // handles on the wrapper and sub nodes
+// Note that it creates an uncontrolled instance
 function makeDefaultWrapper(scale = 1, translation = { x: 0, y: 0 }) {
   const wrapper = mount(
-    <MapInteractionCSS scale={scale} translation={translation}>
+    <MapInteractionCSS defaultScale={scale} defaultTranslation={translation}>
       <div className="child">hello</div>
     </MapInteractionCSS>
   );
@@ -222,8 +223,8 @@ describe("Use case testing", () => {
       <MapInteractionCSS
         showControls
         plusBtnClass="plus-button"
-        scale={initialScale}
-        translation={initialTranslation}
+        defaultScale={initialScale}
+        defaultTranslation={initialTranslation}
       >
         <div className="child" />
       </MapInteractionCSS>

--- a/src/UseCases.test.jsx
+++ b/src/UseCases.test.jsx
@@ -90,7 +90,9 @@ function makeWheelEvent(deltaY = 1) {
 // Note that it creates an uncontrolled instance
 function makeDefaultWrapper(scale = 1, translation = { x: 0, y: 0 }) {
   const wrapper = mount(
-    <MapInteractionCSS defaultScale={scale} defaultTranslation={translation}>
+    <MapInteractionCSS
+      defaultValue={{ scale, translation }}
+    >
       <div className="child">hello</div>
     </MapInteractionCSS>
   );

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -90,8 +90,6 @@ storiesOf('MapInteractionCSS', module)
         <MapInteractionCSS>
           <button
             onClick={(e) => {
-              console.log('inside on click')
-              console.log("e.defaultPrevented: ", e.defaultPrevented);
               if (e.defaultPrevented) {
                 action('Drag!')();
               } else {
@@ -99,8 +97,6 @@ storiesOf('MapInteractionCSS', module)
               }
             }}
             onTouchEnd={(e) => {
-              console.log('inside on click')
-              console.log("e.defaultPrevented: ", e.defaultPrevented);
               if (e.defaultPrevented) {
                 action('Drag!')();
               } else {

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -8,7 +8,7 @@ import gridImg from './grid.png';
 const BLUE_BORDER = '1px solid blue';
 
 storiesOf('MapInteractionCSS', module)
-  .add('Grid', () => {
+  .add('Basic uncontrolled', () => {
     return (
       <div style={{ width: 500, height: 500, border: BLUE_BORDER }}>
         <MapInteractionCSS>
@@ -16,6 +16,73 @@ storiesOf('MapInteractionCSS', module)
         </MapInteractionCSS>
       </div>
     )
+  })
+  .add('Basic controlled', () => {
+    class Controller extends Component {
+      constructor(props) {
+        super(props);
+        this.state = { scale: 1, translation: { x: 0, y: 0 }};
+      }
+
+      render() {
+        return (
+          <div style={{ width: 500, height: 500, border: BLUE_BORDER }}>
+            <MapInteractionCSS
+              translation={this.state.translation}
+              scale={this.state.scale}
+              onChange={(params) => {
+                this.setState(params);
+              }}
+              showControls
+            >
+              <img src={gridImg} style={{ pointerEvents: 'none' }} alt="" />
+            </MapInteractionCSS>
+          </div>
+        );
+      }
+    }
+
+    return <Controller />;
+  })
+  .add('Flip controlled to uncontrolled', () => {
+    class Controller extends Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          scale: 1,
+          translation: { x: 0, y: 0 },
+          controlled: true
+        };
+      }
+
+      render() {
+        const { controlled, scale, translation } = this.state;
+
+        return (
+          <div style={{ width: 500, height: 500, border: BLUE_BORDER }}>
+            <MapInteractionCSS
+              translation={controlled ? translation : undefined}
+              scale={controlled ? scale : undefined}
+              onChange={controlled ? (s) => this.setState(s) : undefined}
+              showControls
+            >
+              <img src={gridImg} style={{ pointerEvents: 'none' }} alt="" />
+            </MapInteractionCSS>
+            <button
+              onClick={() => {
+                this.setState((state) => {
+                  return { controlled: !state.controlled };
+                });
+              }}
+            >
+              flip
+            </button>
+          </div>
+        );
+      }
+    }
+
+    return <Controller />;
   })
   .add('Button inside', () => {
     return (

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -21,17 +21,20 @@ storiesOf('MapInteractionCSS', module)
     class Controller extends Component {
       constructor(props) {
         super(props);
-        this.state = { scale: 1, translation: { x: 0, y: 0 }};
+        this.state = {
+          value: {
+            scale: 1, translation: { x: 0, y: 0 }
+          }
+        };
       }
 
       render() {
         return (
           <div style={{ width: 500, height: 500, border: BLUE_BORDER }}>
             <MapInteractionCSS
-              translation={this.state.translation}
-              scale={this.state.scale}
-              onChange={(params) => {
-                this.setState(params);
+              value={this.state.value}
+              onChange={(value) => {
+                this.setState({ value });
               }}
               showControls
             >
@@ -49,8 +52,10 @@ storiesOf('MapInteractionCSS', module)
       constructor(props) {
         super(props);
         this.state = {
-          scale: 1,
-          translation: { x: 0, y: 0 },
+          value: {
+            scale: 1,
+            translation: { x: 0, y: 0 }
+          },
           controlled: true
         };
       }
@@ -61,9 +66,8 @@ storiesOf('MapInteractionCSS', module)
         return (
           <div style={{ width: 500, height: 500, border: BLUE_BORDER }}>
             <MapInteractionCSS
-              translation={controlled ? translation : undefined}
-              scale={controlled ? scale : undefined}
-              onChange={controlled ? (s) => this.setState(s) : undefined}
+              value={controlled ? this.state.value : undefined}
+              onChange={controlled ? (value) => this.setState({ value }) : undefined}
               showControls
             >
               <img src={gridImg} style={{ pointerEvents: 'none' }} alt="" />


### PR DESCRIPTION
**BREAKING**: To make compatible with React 17, I got rid of componentWillReceiveProps usage. In doing so, I also took the time to simplify the API to MapInteraction to just require `value` and `onChange` when you want to control the component, instead of `scale`, `translation`, and `onChange`. The minimum React peer dependency is now 16.3.

Fixes #39 

**The change**
- No more componentWillReceiveProps
- The RMI API now takes `value` and `onChange`
- We now ask callers to either treat this component as fully controlled (provide `value` and manage the state), or fully uncontrolled (no `value` provided, we manage the state)

**Inspiration**

I tried to match the API to the `<input />` component in the sense that you should either treat it as controlled or uncontrolled, not both. However, if the caller messes up and switches between controlled/uncontrolled it doesn't fail horribly.

https://reactjs.org/docs/dom-elements.html#value
> The value attribute is supported by <input> and <textarea> components. You can use it to set the value of the component. This is useful for building controlled components. defaultValue is the uncontrolled equivalent, which sets the value   of the component when it is first mounted.

This write up is also very insightful about controlled vs uncontrolled:
https://reactalt.org/blog/2018/06/07/you-probably-dont-need-derived-state.html


React `<input />` source checks for control like this:
 https://github.com/facebook/react/blob/03de849af03996b7477420c97de7741ce1214149/packages/react-dom/src/client/ReactDOMInput.js
 ```
 function isControlled(props) {
   const usesChecked = props.type === 'checkbox' || props.type === 'radio';
   return usesChecked ? props.checked != null : props.value != null;
 }
```