### PR TITLE
A solution to https://github.com/transcriptic/react-map-interaction/issues/40

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "private": false,
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.3.0",
+    "react": "^17.0.2",
     "prop-types": "^15.0.0"
   },
   "devDependencies": {

--- a/src/Controls.jsx
+++ b/src/Controls.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-class Controls extends Component {
+class Controls extends PureComponent {
   render() {
     const {
       plusBtnContents,

--- a/src/Controls.jsx
+++ b/src/Controls.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-class Controls extends Component {
+class Controls extends PureComponent {
   render() {
     const {
       plusBtnContents,
@@ -95,4 +95,4 @@ Controls.defaultProps = {
   disableZoom: false
 };
 
-export default Controls;
+export default React.memo(Controls);

--- a/src/Controls.jsx
+++ b/src/Controls.jsx
@@ -1,7 +1,7 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-class Controls extends PureComponent {
+class Controls extends Component {
   render() {
     const {
       plusBtnContents,

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -90,19 +90,20 @@ export class MapInteractionControlled extends Component {
       Setup events for the gesture lifecycle: start, move, end touch
     */
 
-    // start gesture
-    this.getContainerNode().addEventListener('touchstart', this.onTouchStart, passiveOption);
-    this.getContainerNode().addEventListener('mousedown', this.onMouseDown, passiveOption);
+    if (!this.props.textIsHovered) {
+      // start gesture
+      this.getContainerNode().addEventListener('touchstart', this.onTouchStart, passiveOption);
+      this.getContainerNode().addEventListener('mousedown', this.onMouseDown, passiveOption);
 
-    // move gesture
-    window.addEventListener('touchmove', this.onTouchMove, passiveOption);
-    window.addEventListener('mousemove', this.onMouseMove, passiveOption);
+      // move gesture
+      window.addEventListener('touchmove', this.onTouchMove, passiveOption);
+      window.addEventListener('mousemove', this.onMouseMove, passiveOption);
 
-    // end gesture
-    const touchAndMouseEndOptions = { capture: true, ...passiveOption };
-    window.addEventListener('touchend', this.onTouchEnd, touchAndMouseEndOptions);
-    window.addEventListener('mouseup', this.onMouseUp, touchAndMouseEndOptions);
-
+      // end gesture
+      const touchAndMouseEndOptions = { capture: true, ...passiveOption };
+      window.addEventListener('touchend', this.onTouchEnd, touchAndMouseEndOptions);
+      window.addEventListener('mouseup', this.onMouseUp, touchAndMouseEndOptions);
+    }
   }
 
   componentWillUnmount() {
@@ -132,17 +133,13 @@ export class MapInteractionControlled extends Component {
   */
 
   onMouseDown(e) {
-    if (!this.props.textIsHovered) {
-      e.preventDefault();
-      this.setPointerState([e]);
-    }
+    e.preventDefault();
+    this.setPointerState([e]);
   }
 
   onTouchStart(e) {
-    if (!this.props.textIsHovered) {
-      e.preventDefault();
-      this.setPointerState(e.touches);
-    }
+    e.preventDefault();
+    this.setPointerState(e.touches);
   }
 
   onMouseUp(e) {
@@ -157,10 +154,8 @@ export class MapInteractionControlled extends Component {
     if (!this.startPointerInfo || this.props.disablePan) {
       return;
     }
-    if (!this.props.textIsHovered) {
-      e.preventDefault();
-      this.onDrag(e);
-    }
+    e.preventDefault();
+    this.onDrag(e);
   }
 
   onTouchMove(e) {
@@ -168,16 +163,14 @@ export class MapInteractionControlled extends Component {
       return;
     }
 
-    if (!this.props.textIsHovered) {
-      e.preventDefault();
-      const { disablePan, disableZoom } = this.props;
+    e.preventDefault();
+    const { disablePan, disableZoom } = this.props;
 
-      const isPinchAction = e.touches.length == 2 && this.startPointerInfo.pointers.length > 1;
-      if (isPinchAction && !disableZoom) {
-        this.scaleFromMultiTouch(e);
-      } else if ((e.touches.length === 1) && this.startPointerInfo && !disablePan) {
-        this.onDrag(e.touches[0]);
-      }
+    const isPinchAction = e.touches.length == 2 && this.startPointerInfo.pointers.length > 1;
+    if (isPinchAction && !disableZoom) {
+      this.scaleFromMultiTouch(e);
+    } else if ((e.touches.length === 1) && this.startPointerInfo && !disablePan) {
+      this.onDrag(e.touches[0]);
     }
   }
 

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -665,4 +665,4 @@ class MapInteractionController extends PureComponent {
   }
 }
 
-export default react.memo(MapInteractionController);
+export default React.memo(MapInteractionController);

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -532,7 +532,7 @@ onWheel(e) {
   Determines if it's parent is controlling (eg it manages state) or leaving us uncontrolled
   (eg we manage our own internal state)
 */
-class MapInteractionController extends Component {
+class MapInteractionController extends PureComponent {
   static get propTypes() {
     return {
       children: PropTypes.func,
@@ -665,4 +665,4 @@ class MapInteractionController extends Component {
   }
 }
 
-export default MapInteractionController;
+export default react.memo(MapInteractionController);

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -145,15 +145,11 @@ export class MapInteractionControlled extends Component {
   }
 
   onMouseUp(e) {
-    if (!this.props.textIsHovered) {
-      this.setPointerState();
-    }
+    this.setPointerState();
   }
 
   onTouchEnd(e) {
-    if (!this.props.textIsHovered) {
-      this.setPointerState(e.touches);
-    }
+    this.setPointerState(e.touches);
   }
 
   onMouseMove(e) {

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -239,52 +239,71 @@ export class MapInteractionControlled extends Component {
   }
 
   onWheel(e) {
-    if (this.props.disableZoom) {
-      return;
-    }
-    if (e.ctrlKey) {
-      const scaleChange = 2 ** (e.deltaY * 0.02); // changed from 0.002. Now 10x faster. Better zooming experience, esp on trackpad.
+		if (this.props.disableZoom) {
+			return
+		}
 
-      const newScale = clamp(
-        this.props.minScale,
-        this.props.value.scale + (1 - scaleChange),
-        this.props.maxScale
-      );
+		// React does not currently support e.webkitForce and e.mozInputSource. Check again later.
+		if (e.ctrlKey && !e.altKey) {
+			const scaleChange = 2 ** (e.deltaY * 0.02) // use Cntrl for trackpad Zoom
 
-      const mousePos = this.clientPosToTranslatedPos({
-        x: e.clientX,
-        y: e.clientY,
-      });
+			const newScale = clamp(
+				this.props.minScale,
+				this.props.value.scale + (1 - scaleChange),
+				this.props.maxScale
+			)
 
-      this.scaleFromPoint(newScale, mousePos);
-    } else {
-      const translation = this.props.value.translation;
+			const mousePos = this.clientPosToTranslatedPos({
+				x: e.clientX,
+				y: e.clientY,
+			})
 
-      const dragX = e.deltaX;
-      const dragY = e.deltaY;
-      const newTranslation = {
-        x: translation.x - dragX,
-        y: translation.y - dragY,
-      };
+			this.scaleFromPoint(newScale, mousePos)
+		} else if (!e.ctrlKey && e.altKey) {
+			const scaleChange = 2 ** (e.deltaY * 0.002) // use alt for mouseWheel Zoom
 
-      const shouldPreventTouchEndDefault =
-        Math.abs(dragX) > 1 || Math.abs(dragY) > 1;
+			const newScale = clamp(
+				this.props.minScale,
+				this.props.value.scale + (1 - scaleChange),
+				this.props.maxScale
+			)
 
-      this.setState(
-        {
-          shouldPreventTouchEndDefault,
-        },
-        () => {
-          this.props.onChange({
-            scale: this.props.value.scale,
-            translation: this.clampTranslation(newTranslation),
-          });
-        }
-      );
-    }
-    e.preventDefault();
-    e.stopPropagation();
-  }
+			const mousePos = this.clientPosToTranslatedPos({
+				x: e.clientX,
+				y: e.clientY,
+			})
+
+			this.scaleFromPoint(newScale, mousePos)
+		} 
+		else if (!e.ctrlKey && !e.altKey) {
+			const translation = this.props.value.translation
+
+			const dragX = e.deltaX
+			const dragY = e.deltaY
+			const newTranslation = {
+				x: translation.x - dragX,
+				y: translation.y - dragY,
+			}
+
+			const shouldPreventTouchEndDefault =
+				Math.abs(dragX) > 1 || Math.abs(dragY) > 1
+
+			this.setState(
+				{
+					shouldPreventTouchEndDefault,
+				},
+				() => {
+					this.props.onChange({
+						scale: this.props.value.scale,
+						translation: this.clampTranslation(newTranslation),
+					})
+				}
+			)
+
+			e.preventDefault()
+			e.stopPropagation()
+		}
+	}
 
   setPointerState(pointers) {
     if (!pointers || pointers.length === 0) {

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -243,7 +243,7 @@ export class MapInteractionControlled extends Component {
       return;
     }
     if (e.ctrlKey) {
-      const scaleChange = 2 ** (e.deltaY * 0.002);
+      const scaleChange = 2 ** (e.deltaY * 0.02); // changed from 0.002. Now 10x faster. Better zooming experience, esp on trackpad.
 
       const newScale = clamp(
         this.props.minScale,

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -665,4 +665,4 @@ class MapInteractionController extends Component {
   }
 }
 
-export default React.memo(MapInteractionController);
+export default MapInteractionController;

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -373,7 +373,7 @@ onWheel(e) {
   // to achieve the effect of keeping the content that was directly
   // in the middle of the two fingers as the focal point throughout the zoom.
   scaleFromMultiTouch(e) {
-    /*
+    
     const startTouches = this.startPointerInfo.pointers;
     const newTouches = e.touches;
 
@@ -433,7 +433,7 @@ onWheel(e) {
       scale: newScale,
       translation: this.clampTranslation(newTranslation),
     });
-    */
+    
   }
 
   discreteScaleStepSize() {

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -132,13 +132,17 @@ export class MapInteractionControlled extends Component {
   */
 
   onMouseDown(e) {
-    e.preventDefault();
-    this.setPointerState([e]);
+    if (!this.props.isHovering) {
+      e.preventDefault();
+      this.setPointerState([e]);
+    }
   }
 
   onTouchStart(e) {
-    e.preventDefault();
-    this.setPointerState(e.touches);
+    if (!this.props.isHovering) {
+      e.preventDefault();
+      this.setPointerState(e.touches);
+    }
   }
 
   onMouseUp(e) {
@@ -153,8 +157,10 @@ export class MapInteractionControlled extends Component {
     if (!this.startPointerInfo || this.props.disablePan) {
       return;
     }
-    e.preventDefault();
-    this.onDrag(e);
+    if (!this.props.isHovering) {
+      e.preventDefault();
+      this.onDrag(e);
+    }
   }
 
   onTouchMove(e) {
@@ -162,15 +168,16 @@ export class MapInteractionControlled extends Component {
       return;
     }
 
-    e.preventDefault();
+    if (!this.props.isHovering) {
+      e.preventDefault();
+      const { disablePan, disableZoom } = this.props;
 
-    const { disablePan, disableZoom } = this.props;
-
-    const isPinchAction = e.touches.length == 2 && this.startPointerInfo.pointers.length > 1;
-    if (isPinchAction && !disableZoom) {
-      this.scaleFromMultiTouch(e);
-    } else if ((e.touches.length === 1) && this.startPointerInfo && !disablePan) {
-      this.onDrag(e.touches[0]);
+      const isPinchAction = e.touches.length == 2 && this.startPointerInfo.pointers.length > 1;
+      if (isPinchAction && !disableZoom) {
+        this.scaleFromMultiTouch(e);
+      } else if ((e.touches.length === 1) && this.startPointerInfo && !disablePan) {
+        this.onDrag(e.touches[0]);
+      }
     }
   }
 

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -238,72 +238,68 @@ export class MapInteractionControlled extends Component {
     );
   }
 
-  onWheel(e) {
-		if (this.props.disableZoom) {
-			return
-		}
+onWheel(e) {
+    if (this.props.disableZoom) {
+      return;
+    }
+    if (e.ctrlKey && !e.altKey) {
+      const scaleChange = 2 ** (e.deltaY * 0.02) // use Cntrl for trackpad Zoom
 
-		// React does not currently support e.webkitForce and e.mozInputSource. Check again later.
-		if (e.ctrlKey && !e.altKey) {
-			const scaleChange = 2 ** (e.deltaY * 0.02) // use Cntrl for trackpad Zoom
+      const newScale = clamp(
+        this.props.minScale,
+        this.props.value.scale + (1 - scaleChange),
+        this.props.maxScale
+      );
 
-			const newScale = clamp(
-				this.props.minScale,
-				this.props.value.scale + (1 - scaleChange),
-				this.props.maxScale
-			)
+      const mousePos = this.clientPosToTranslatedPos({
+        x: e.clientX,
+        y: e.clientY,
+      });
 
-			const mousePos = this.clientPosToTranslatedPos({
-				x: e.clientX,
-				y: e.clientY,
-			})
+      this.scaleFromPoint(newScale, mousePos);
+    } else if (!e.ctrlKey && e.altKey) {
+      const scaleChange = 2 ** (e.deltaY * 0.002) // use alt for mouseWheel Zoom
 
-			this.scaleFromPoint(newScale, mousePos)
-		} else if (!e.ctrlKey && e.altKey) {
-			const scaleChange = 2 ** (e.deltaY * 0.002) // use alt for mouseWheel Zoom
+      const newScale = clamp(
+        this.props.minScale,
+        this.props.value.scale + (1 - scaleChange),
+        this.props.maxScale
+      );
 
-			const newScale = clamp(
-				this.props.minScale,
-				this.props.value.scale + (1 - scaleChange),
-				this.props.maxScale
-			)
+      const mousePos = this.clientPosToTranslatedPos({
+        x: e.clientX,
+        y: e.clientY,
+      });
 
-			const mousePos = this.clientPosToTranslatedPos({
-				x: e.clientX,
-				y: e.clientY,
-			})
+      this.scaleFromPoint(newScale, mousePos);
+    } else if (!e.ctrlKey && !e.altKey) {
+      const translation = this.props.value.translation;
 
-			this.scaleFromPoint(newScale, mousePos)
-		} 
-		else if (!e.ctrlKey && !e.altKey) {
-			const translation = this.props.value.translation
+      const dragX = e.deltaX;
+      const dragY = e.deltaY;
+      const newTranslation = {
+        x: translation.x - dragX,
+        y: translation.y - dragY,
+      };
 
-			const dragX = e.deltaX
-			const dragY = e.deltaY
-			const newTranslation = {
-				x: translation.x - dragX,
-				y: translation.y - dragY,
-			}
+      const shouldPreventTouchEndDefault =
+        Math.abs(dragX) > 1 || Math.abs(dragY) > 1;
 
-			const shouldPreventTouchEndDefault =
-				Math.abs(dragX) > 1 || Math.abs(dragY) > 1
-
-			this.setState(
-				{
-					shouldPreventTouchEndDefault,
-				},
-				() => {
-					this.props.onChange({
-						scale: this.props.value.scale,
-						translation: this.clampTranslation(newTranslation),
-					})
-				}
-			)
-
-			e.preventDefault()
-			e.stopPropagation()
-		}
-	}
+      this.setState(
+        {
+          shouldPreventTouchEndDefault,
+        },
+        () => {
+          this.props.onChange({
+            scale: this.props.value.scale,
+            translation: this.clampTranslation(newTranslation),
+          });
+        }
+      );
+    }
+    e.preventDefault();
+    e.stopPropagation();
+  }
 
   setPointerState(pointers) {
     if (!pointers || pointers.length === 0) {

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -1,4 +1,4 @@
-import React, { PueComponent } from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 
 import Controls from "./Controls";

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { PueComponent } from "react";
 import PropTypes from "prop-types";
 
 import Controls from "./Controls";
@@ -22,7 +22,7 @@ const translationShape = PropTypes.shape({
   It renders its children with the current state of the translation and does not do any scaling
   or translating on its own. This works on both desktop, and mobile.
 */
-export class MapInteractionControlled extends Component {
+export class MapInteractionControlled extends PureComponent {
   static get propTypes() {
     return {
       // The content that will be transformed
@@ -665,4 +665,4 @@ class MapInteractionController extends Component {
   }
 }
 
-export default MapInteractionController;
+export default React.memo(MapInteractionController);

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 import Controls from "./Controls";
@@ -22,7 +22,7 @@ const translationShape = PropTypes.shape({
   It renders its children with the current state of the translation and does not do any scaling
   or translating on its own. This works on both desktop, and mobile.
 */
-export class MapInteractionControlled extends PureComponent {
+export class MapInteractionControlled extends Component {
   static get propTypes() {
     return {
       // The content that will be transformed

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -90,20 +90,18 @@ export class MapInteractionControlled extends Component {
       Setup events for the gesture lifecycle: start, move, end touch
     */
 
-    if (!this.props.textIsHovered) {
-      // start gesture
-      this.getContainerNode().addEventListener('touchstart', this.onTouchStart, passiveOption);
-      this.getContainerNode().addEventListener('mousedown', this.onMouseDown, passiveOption);
+    // start gesture
+    this.getContainerNode().addEventListener('touchstart', this.onTouchStart, passiveOption);
+    this.getContainerNode().addEventListener('mousedown', this.onMouseDown, passiveOption);
 
-      // move gesture
-      window.addEventListener('touchmove', this.onTouchMove, passiveOption);
-      window.addEventListener('mousemove', this.onMouseMove, passiveOption);
+    // move gesture
+    window.addEventListener('touchmove', this.onTouchMove, passiveOption);
+    window.addEventListener('mousemove', this.onMouseMove, passiveOption);
 
-      // end gesture
-      const touchAndMouseEndOptions = { capture: true, ...passiveOption };
-      window.addEventListener('touchend', this.onTouchEnd, touchAndMouseEndOptions);
-      window.addEventListener('mouseup', this.onMouseUp, touchAndMouseEndOptions);
-    }
+    // end gesture
+    const touchAndMouseEndOptions = { capture: true, ...passiveOption };
+    window.addEventListener('touchend', this.onTouchEnd, touchAndMouseEndOptions);
+    window.addEventListener('mouseup', this.onMouseUp, touchAndMouseEndOptions);
   }
 
   componentWillUnmount() {
@@ -133,44 +131,56 @@ export class MapInteractionControlled extends Component {
   */
 
   onMouseDown(e) {
-    e.preventDefault();
-    this.setPointerState([e]);
+    if (!this.props.textIsHovered) {
+      e.preventDefault();
+      this.setPointerState([e]);
+    }
   }
 
   onTouchStart(e) {
-    e.preventDefault();
-    this.setPointerState(e.touches);
+    if (!this.props.textIsHovered) {
+      e.preventDefault();
+      this.setPointerState(e.touches);
+    }
   }
 
   onMouseUp(e) {
-    this.setPointerState();
+    if (!this.props.textIsHovered) {
+      this.setPointerState();
+    }
   }
 
   onTouchEnd(e) {
-    this.setPointerState(e.touches);
+    if (!this.props.textIsHovered) {
+      this.setPointerState(e.touches);
+    }
   }
 
   onMouseMove(e) {
-    if (!this.startPointerInfo || this.props.disablePan) {
-      return;
+    if (!this.props.textIsHovered) {
+      if (!this.startPointerInfo || this.props.disablePan) {
+        return;
+      }
+      e.preventDefault();
+      this.onDrag(e);
     }
-    e.preventDefault();
-    this.onDrag(e);
   }
 
   onTouchMove(e) {
-    if (!this.startPointerInfo) {
-      return;
-    }
+    if (!this.props.textIsHovered) {
+      if (!this.startPointerInfo) {
+        return;
+      }
 
-    e.preventDefault();
-    const { disablePan, disableZoom } = this.props;
+      e.preventDefault();
+      const { disablePan, disableZoom } = this.props;
 
-    const isPinchAction = e.touches.length == 2 && this.startPointerInfo.pointers.length > 1;
-    if (isPinchAction && !disableZoom) {
-      this.scaleFromMultiTouch(e);
-    } else if ((e.touches.length === 1) && this.startPointerInfo && !disablePan) {
-      this.onDrag(e.touches[0]);
+      const isPinchAction = e.touches.length == 2 && this.startPointerInfo.pointers.length > 1;
+      if (isPinchAction && !disableZoom) {
+        this.scaleFromMultiTouch(e);
+      } else if ((e.touches.length === 1) && this.startPointerInfo && !disablePan) {
+        this.onDrag(e.touches[0]);
+      }
     }
   }
 

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, PureComponent } from "react";
 import PropTypes from "prop-types";
 
 import Controls from "./Controls";
@@ -22,7 +22,7 @@ const translationShape = PropTypes.shape({
   It renders its children with the current state of the translation and does not do any scaling
   or translating on its own. This works on both desktop, and mobile.
 */
-export class MapInteractionControlled extends Component {
+export class MapInteractionControlled extends PureComponent {
   static get propTypes() {
     return {
       // The content that will be transformed
@@ -532,7 +532,7 @@ onWheel(e) {
   Determines if it's parent is controlling (eg it manages state) or leaving us uncontrolled
   (eg we manage our own internal state)
 */
-class MapInteractionController extends PureComponent {
+class MapInteractionController extends Component {
   static get propTypes() {
     return {
       children: PropTypes.func,

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -132,14 +132,14 @@ export class MapInteractionControlled extends Component {
   */
 
   onMouseDown(e) {
-    if (!this.props.isHovering) {
+    if (!this.props.textIsHovered) {
       e.preventDefault();
       this.setPointerState([e]);
     }
   }
 
   onTouchStart(e) {
-    if (!this.props.isHovering) {
+    if (!this.props.textIsHovered) {
       e.preventDefault();
       this.setPointerState(e.touches);
     }
@@ -157,7 +157,7 @@ export class MapInteractionControlled extends Component {
     if (!this.startPointerInfo || this.props.disablePan) {
       return;
     }
-    if (!this.props.isHovering) {
+    if (!this.props.textIsHovered) {
       e.preventDefault();
       this.onDrag(e);
     }
@@ -168,7 +168,7 @@ export class MapInteractionControlled extends Component {
       return;
     }
 
-    if (!this.props.isHovering) {
+    if (!this.props.textIsHovered) {
       e.preventDefault();
       const { disablePan, disableZoom } = this.props;
 

--- a/src/MapInteraction.jsx
+++ b/src/MapInteraction.jsx
@@ -1,17 +1,20 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
-import Controls from './Controls';
+import Controls from "./Controls";
 
-import { clamp, distance, midpoint, touchPt, touchDistance } from './geometry';
-import makePassiveEventOption from './makePassiveEventOption';
+import { clamp, distance, midpoint, touchPt, touchDistance } from "./geometry";
+import makePassiveEventOption from "./makePassiveEventOption";
 
 // The amount that a value of a dimension will change given a new scale
 const coordChange = (coordinate, scaleRatio) => {
-  return (scaleRatio * coordinate) - coordinate;
+  return scaleRatio * coordinate - coordinate;
 };
 
-const translationShape = PropTypes.shape({ x: PropTypes.number, y: PropTypes.number });
+const translationShape = PropTypes.shape({
+  x: PropTypes.number,
+  y: PropTypes.number,
+});
 
 /*
   This contains logic for providing a map-like interaction to any DOM node.
@@ -35,7 +38,10 @@ export class MapInteractionControlled extends Component {
       disableZoom: PropTypes.bool,
       disablePan: PropTypes.bool,
       translationBounds: PropTypes.shape({
-        xMin: PropTypes.number, xMax: PropTypes.number, yMin: PropTypes.number, yMax: PropTypes.number
+        xMin: PropTypes.number,
+        xMax: PropTypes.number,
+        yMin: PropTypes.number,
+        yMax: PropTypes.number,
       }),
       minScale: PropTypes.number,
       maxScale: PropTypes.number,
@@ -45,7 +51,7 @@ export class MapInteractionControlled extends Component {
       btnClass: PropTypes.string,
       plusBtnClass: PropTypes.string,
       minusBtnClass: PropTypes.string,
-      controlsClass: PropTypes.string
+      controlsClass: PropTypes.string,
     };
   }
 
@@ -56,7 +62,7 @@ export class MapInteractionControlled extends Component {
       showControls: false,
       translationBounds: {},
       disableZoom: false,
-      disablePan: false
+      disablePan: false,
     };
   }
 
@@ -64,7 +70,7 @@ export class MapInteractionControlled extends Component {
     super(props);
 
     this.state = {
-      shouldPreventTouchEndDefault: false
+      shouldPreventTouchEndDefault: false,
     };
 
     this.startPointerInfo = undefined;
@@ -84,38 +90,63 @@ export class MapInteractionControlled extends Component {
   componentDidMount() {
     const passiveOption = makePassiveEventOption(false);
 
-    this.getContainerNode().addEventListener('wheel', this.onWheel, passiveOption);
+    this.getContainerNode().addEventListener(
+      "wheel",
+      this.onWheel,
+      passiveOption
+    );
 
     /*
       Setup events for the gesture lifecycle: start, move, end touch
     */
 
     // start gesture
-    this.getContainerNode().addEventListener('touchstart', this.onTouchStart, passiveOption);
-    this.getContainerNode().addEventListener('mousedown', this.onMouseDown, passiveOption);
+    this.getContainerNode().addEventListener(
+      "touchstart",
+      this.onTouchStart,
+      passiveOption
+    );
+    this.getContainerNode().addEventListener(
+      "mousedown",
+      this.onMouseDown,
+      passiveOption
+    );
+    this.getContainerNode().addEventListener("wheel", this.onWheel);
 
     // move gesture
-    window.addEventListener('touchmove', this.onTouchMove, passiveOption);
-    window.addEventListener('mousemove', this.onMouseMove, passiveOption);
+    window.addEventListener("touchmove", this.onTouchMove, passiveOption);
+    window.addEventListener("mousemove", this.onMouseMove, passiveOption);
 
     // end gesture
     const touchAndMouseEndOptions = { capture: true, ...passiveOption };
-    window.addEventListener('touchend', this.onTouchEnd, touchAndMouseEndOptions);
-    window.addEventListener('mouseup', this.onMouseUp, touchAndMouseEndOptions);
+    window.addEventListener(
+      "touchend",
+      this.onTouchEnd,
+      touchAndMouseEndOptions
+    );
+    window.addEventListener("mouseup", this.onMouseUp, touchAndMouseEndOptions);
+    window.addEventListener("gesturemove", function (e) {
+    });
   }
 
   componentWillUnmount() {
-    this.getContainerNode().removeEventListener('wheel', this.onWheel);
+    this.getContainerNode().removeEventListener("wheel", this.onWheel);
 
     // Remove touch events
-    this.getContainerNode().removeEventListener('touchstart', this.onTouchStart);
-    window.removeEventListener('touchmove', this.onTouchMove);
-    window.removeEventListener('touchend', this.onTouchEnd);
+    this.getContainerNode().removeEventListener(
+      "touchstart",
+      this.onTouchStart
+    );
+    window.removeEventListener("touchmove", this.onTouchMove);
+    window.removeEventListener("touchend", this.onTouchEnd);
 
     // Remove mouse events
-    this.getContainerNode().removeEventListener('mousedown', this.onMouseDown);
-    window.removeEventListener('mousemove', this.onMouseMove);
-    window.removeEventListener('mouseup', this.onMouseUp);
+    this.getContainerNode().removeEventListener("mousedown", this.onMouseDown);
+    window.removeEventListener("mousemove", this.onMouseMove);
+    window.removeEventListener("mouseup", this.onMouseUp);
+    window.addEventListener("wheel", (e) => {
+      e.preventDefault();
+    });
   }
 
   /*
@@ -163,20 +194,20 @@ export class MapInteractionControlled extends Component {
   }
 
   onTouchMove(e) {
-    if (!this.props.textIsHovered) {
-      if (!this.startPointerInfo) {
-        return;
-      }
+    if (!this.startPointerInfo) {
+      return;
+    }
 
-      e.preventDefault();
-      const { disablePan, disableZoom } = this.props;
+    e.preventDefault();
 
-      const isPinchAction = e.touches.length == 2 && this.startPointerInfo.pointers.length > 1;
-      if (isPinchAction && !disableZoom) {
-        this.scaleFromMultiTouch(e);
-      } else if ((e.touches.length === 1) && this.startPointerInfo && !disablePan) {
-        this.onDrag(e.touches[0]);
-      }
+    const { disablePan, disableZoom } = this.props;
+
+    const isPinchAction =
+      e.touches.length == 2 && this.startPointerInfo.pointers.length > 1;
+    if (isPinchAction && !disableZoom) {
+      this.scaleFromMultiTouch(e);
+    } else if (e.touches.length === 1 && this.startPointerInfo && !disablePan) {
+      this.onDrag(e.touches[0]);
     }
   }
 
@@ -188,40 +219,71 @@ export class MapInteractionControlled extends Component {
     const dragY = pointer.clientY - startPointer.clientY;
     const newTranslation = {
       x: translation.x + dragX,
-      y: translation.y + dragY
+      y: translation.y + dragY,
     };
 
-    const shouldPreventTouchEndDefault = Math.abs(dragX) > 1 || Math.abs(dragY) > 1;
+    const shouldPreventTouchEndDefault =
+      Math.abs(dragX) > 1 || Math.abs(dragY) > 1;
 
-    this.setState({
-      shouldPreventTouchEndDefault
-    }, () => {
-      this.props.onChange({
-        scale: this.props.value.scale,
-        translation: this.clampTranslation(newTranslation)
-      });
-    });
+    this.setState(
+      {
+        shouldPreventTouchEndDefault,
+      },
+      () => {
+        this.props.onChange({
+          scale: this.props.value.scale,
+          translation: this.clampTranslation(newTranslation),
+        });
+      }
+    );
   }
 
   onWheel(e) {
     if (this.props.disableZoom) {
       return;
     }
+    if (e.ctrlKey) {
+      const scaleChange = 2 ** (e.deltaY * 0.002);
 
+      const newScale = clamp(
+        this.props.minScale,
+        this.props.value.scale + (1 - scaleChange),
+        this.props.maxScale
+      );
+
+      const mousePos = this.clientPosToTranslatedPos({
+        x: e.clientX,
+        y: e.clientY,
+      });
+
+      this.scaleFromPoint(newScale, mousePos);
+    } else {
+      const translation = this.props.value.translation;
+
+      const dragX = e.deltaX;
+      const dragY = e.deltaY;
+      const newTranslation = {
+        x: translation.x - dragX,
+        y: translation.y - dragY,
+      };
+
+      const shouldPreventTouchEndDefault =
+        Math.abs(dragX) > 1 || Math.abs(dragY) > 1;
+
+      this.setState(
+        {
+          shouldPreventTouchEndDefault,
+        },
+        () => {
+          this.props.onChange({
+            scale: this.props.value.scale,
+            translation: this.clampTranslation(newTranslation),
+          });
+        }
+      );
+    }
     e.preventDefault();
     e.stopPropagation();
-
-    const scaleChange = 2 ** (e.deltaY * 0.002);
-
-    const newScale = clamp(
-      this.props.minScale,
-      this.props.value.scale + (1 - scaleChange),
-      this.props.maxScale
-    );
-
-    const mousePos = this.clientPosToTranslatedPos({ x: e.clientX, y: e.clientY });
-
-    this.scaleFromPoint(newScale, mousePos);
   }
 
   setPointerState(pointers) {
@@ -234,7 +296,7 @@ export class MapInteractionControlled extends Component {
       pointers,
       scale: this.props.value.scale,
       translation: this.props.value.translation,
-    }
+    };
   }
 
   clampTranslation(desiredTranslation, props = this.props) {
@@ -247,7 +309,7 @@ export class MapInteractionControlled extends Component {
 
     return {
       x: clamp(xMin, x, xMax),
-      y: clamp(yMin, y, yMax)
+      y: clamp(yMin, y, yMax),
     };
   }
 
@@ -255,17 +317,20 @@ export class MapInteractionControlled extends Component {
     const clientOffset = this.getContainerBoundingClientRect();
     return {
       x: clientOffset.left + translation.x,
-      y: clientOffset.top + translation.y
+      y: clientOffset.top + translation.y,
     };
   }
 
   // From a given screen point return it as a point
   // in the coordinate system of the given translation
-  clientPosToTranslatedPos({ x, y }, translation = this.props.value.translation) {
+  clientPosToTranslatedPos(
+    { x, y },
+    translation = this.props.value.translation
+  ) {
     const origin = this.translatedOrigin(translation);
     return {
       x: x - origin.x,
-      y: y - origin.y
+      y: y - origin.y,
     };
   }
 
@@ -275,17 +340,17 @@ export class MapInteractionControlled extends Component {
 
     const focalPtDelta = {
       x: coordChange(focalPt.x, scaleRatio),
-      y: coordChange(focalPt.y, scaleRatio)
+      y: coordChange(focalPt.y, scaleRatio),
     };
 
     const newTranslation = {
       x: translation.x - focalPtDelta.x,
-      y: translation.y - focalPtDelta.y
+      y: translation.y - focalPtDelta.y,
     };
     this.props.onChange({
       scale: newScale,
-      translation: this.clampTranslation(newTranslation)
-    })
+      translation: this.clampTranslation(newTranslation),
+    });
   }
 
   // Given the start touches and new e.touches, scale and translate
@@ -293,38 +358,52 @@ export class MapInteractionControlled extends Component {
   // to achieve the effect of keeping the content that was directly
   // in the middle of the two fingers as the focal point throughout the zoom.
   scaleFromMultiTouch(e) {
+    /*
     const startTouches = this.startPointerInfo.pointers;
-    const newTouches   = e.touches;
+    const newTouches = e.touches;
 
     // calculate new scale
-    const dist0       = touchDistance(startTouches[0], startTouches[1]);
-    const dist1       = touchDistance(newTouches[0], newTouches[1]);
+    const dist0 = touchDistance(startTouches[0], startTouches[1]);
+    const dist1 = touchDistance(newTouches[0], newTouches[1]);
     const scaleChange = dist1 / dist0;
 
-    const startScale  = this.startPointerInfo.scale;
-    const targetScale = startScale + ((scaleChange - 1) * startScale);
-    const newScale    = clamp(this.props.minScale, targetScale, this.props.maxScale);
+    const startScale = this.startPointerInfo.scale;
+    const targetScale = startScale + (scaleChange - 1) * startScale;
+    const newScale = clamp(
+      this.props.minScale,
+      targetScale,
+      this.props.maxScale
+    );
 
     // calculate mid points
-    const startMidpoint = midpoint(touchPt(startTouches[0]), touchPt(startTouches[1]))
-    const newMidPoint   = midpoint(touchPt(newTouches[0]), touchPt(newTouches[1]));
+    const startMidpoint = midpoint(
+      touchPt(startTouches[0]),
+      touchPt(startTouches[1])
+    );
+    const newMidPoint = midpoint(
+      touchPt(newTouches[0]),
+      touchPt(newTouches[1])
+    );
 
     // The amount we need to translate by in order for
     // the mid point to stay in the middle (before thinking about scaling factor)
     const dragDelta = {
       x: newMidPoint.x - startMidpoint.x,
-      y: newMidPoint.y - startMidpoint.y
+      y: newMidPoint.y - startMidpoint.y,
     };
 
     const scaleRatio = newScale / startScale;
 
     // The point originally in the middle of the fingers on the initial zoom start
-    const focalPt = this.clientPosToTranslatedPos(startMidpoint, this.startPointerInfo.translation);
+    const focalPt = this.clientPosToTranslatedPos(
+      startMidpoint,
+      this.startPointerInfo.translation
+    );
 
     // The amount that the middle point has changed from this scaling
     const focalPtDelta = {
       x: coordChange(focalPt.x, scaleRatio),
-      y: coordChange(focalPt.y, scaleRatio)
+      y: coordChange(focalPt.y, scaleRatio),
     };
 
     // Translation is the original translation, plus the amount we dragged,
@@ -332,13 +411,14 @@ export class MapInteractionControlled extends Component {
     // scaling factor keeps the midpoint in the middle of the touch points.
     const newTranslation = {
       x: this.startPointerInfo.translation.x - focalPtDelta.x + dragDelta.x,
-      y: this.startPointerInfo.translation.y - focalPtDelta.y + dragDelta.y
+      y: this.startPointerInfo.translation.y - focalPtDelta.y + dragDelta.y,
     };
 
     this.props.onChange({
       scale: newScale,
-      translation: this.clampTranslation(newTranslation)
+      translation: this.clampTranslation(newTranslation),
     });
+    */
   }
 
   discreteScaleStepSize() {
@@ -354,15 +434,17 @@ export class MapInteractionControlled extends Component {
     const scale = clamp(minScale, targetScale, maxScale);
 
     const rect = this.getContainerBoundingClientRect();
-    const x = rect.left + (rect.width / 2);
-    const y = rect.top + (rect.height / 2);
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
 
     const focalPoint = this.clientPosToTranslatedPos({ x, y });
     this.scaleFromPoint(scale, focalPoint);
   }
 
   // Done like this so it is mockable
-  getContainerNode() { return this.containerNode }
+  getContainerNode() {
+    return this.containerNode;
+  }
   getContainerBoundingClientRect() {
     return this.getContainerNode().getBoundingClientRect();
   }
@@ -407,7 +489,7 @@ export class MapInteractionControlled extends Component {
         e.preventDefault();
         this.setState({ shouldPreventTouchEndDefault: false });
       }
-    }
+    };
 
     return (
       <div
@@ -415,10 +497,10 @@ export class MapInteractionControlled extends Component {
           this.containerNode = node;
         }}
         style={{
-          height: '100%',
-          width: '100%',
-          position: 'relative', // for absolutely positioned children
-          touchAction: 'none'
+          height: "100%",
+          width: "100%",
+          position: "relative", // for absolutely positioned children
+          touchAction: "none",
         }}
         onClickCapture={handleEventCapture}
         onTouchEndCapture={handleEventCapture}
@@ -451,7 +533,10 @@ class MapInteractionController extends Component {
       disablePan: PropTypes.bool,
       onChange: PropTypes.func,
       translationBounds: PropTypes.shape({
-        xMin: PropTypes.number, xMax: PropTypes.number, yMin: PropTypes.number, yMax: PropTypes.number
+        xMin: PropTypes.number,
+        xMax: PropTypes.number,
+        yMin: PropTypes.number,
+        yMax: PropTypes.number,
       }),
       minScale: PropTypes.number,
       maxScale: PropTypes.number,
@@ -461,7 +546,7 @@ class MapInteractionController extends Component {
       btnClass: PropTypes.string,
       plusBtnClass: PropTypes.string,
       minusBtnClass: PropTypes.string,
-      controlsClass: PropTypes.string
+      controlsClass: PropTypes.string,
     };
   }
 
@@ -471,16 +556,16 @@ class MapInteractionController extends Component {
     const controlled = MapInteractionController.isControlled(props);
     if (controlled) {
       this.state = {
-        lastKnownValueFromProps: props.value
+        lastKnownValueFromProps: props.value,
       };
     } else {
       // Set the necessary state for controlling map interaction ourselves
       this.state = {
         value: props.defaultValue || {
           scale: 1,
-          translation: { x: 0, y: 0 }
+          translation: { x: 0, y: 0 },
         },
-        lastKnownValueFromProps: undefined
+        lastKnownValueFromProps: undefined,
       };
     }
   }
@@ -496,7 +581,11 @@ class MapInteractionController extends Component {
   */
   static getDerivedStateFromProps(props, state) {
     const nowControlled = MapInteractionController.isControlled(props);
-    const wasControlled = state.lastKnownValueFromProps && MapInteractionController.isControlled({ value: state.lastKnownValueFromProps })
+    const wasControlled =
+      state.lastKnownValueFromProps &&
+      MapInteractionController.isControlled({
+        value: state.lastKnownValueFromProps,
+      });
 
     /*
       State transitions:
@@ -511,12 +600,12 @@ class MapInteractionController extends Component {
     if (!wasControlled && nowControlled) {
       return {
         value: undefined,
-        lastKnownValueFromProps: props.value
+        lastKnownValueFromProps: props.value,
       };
     } else if (wasControlled && !nowControlled) {
       return {
         value: state.lastKnownValueFromProps,
-        lastKnownValueFromProps: undefined
+        lastKnownValueFromProps: undefined,
       };
     } else if (wasControlled && nowControlled) {
       return { lastKnownValueFromProps: props.value };
@@ -555,7 +644,7 @@ class MapInteractionController extends Component {
         value={value}
         {...this.innerProps()}
       >
-       {children}
+        {children}
       </MapInteractionControlled>
     );
   }

--- a/src/MapInteractionCSS.jsx
+++ b/src/MapInteractionCSS.jsx
@@ -18,7 +18,7 @@ const MapInteractionCSS = (props) => {
             position: 'relative', // for absolutely positioned children
             overflow: 'hidden',
           };
-          if (!this.props.textIsHovered) {
+          if (!props.textIsHovered) {
             wrapperStyle = {
               ...wrapperStyle,
               touchAction: 'none', // Not supported in Safari :(

--- a/src/MapInteractionCSS.jsx
+++ b/src/MapInteractionCSS.jsx
@@ -12,20 +12,26 @@ const MapInteractionCSS = (props) => {
         ({ translation, scale }) => {
           // Translate first and then scale.  Otherwise, the scale would affect the translation.
           const transform = `translate(${translation.x}px, ${translation.y}px) scale(${scale})`;
+          let wrapperStyle = {
+            height: '100%',
+            width: '100%',
+            position: 'relative', // for absolutely positioned children
+            overflow: 'hidden',
+          };
+          if (!this.props.textIsHovered) {
+            wrapperStyle = {
+              ...wrapperStyle,
+              touchAction: 'none', // Not supported in Safari :(
+              msTouchAction: 'none',
+              cursor: 'all-scroll',
+              WebkitUserSelect: 'none',
+              MozUserSelect: 'none',
+              msUserSelect: 'none'
+            };
+          }
           return (
             <div
-              style={{
-                height: '100%',
-                width: '100%',
-                position: 'relative', // for absolutely positioned children
-                overflow: 'hidden',
-                touchAction: 'none', // Not supported in Safari :(
-                msTouchAction: 'none',
-                cursor: 'all-scroll',
-                WebkitUserSelect: 'none',
-                MozUserSelect: 'none',
-                msUserSelect: 'none'
-              }}
+              style={wrapperStyle}
             >
               <div
                 style={{

--- a/src/MapInteractionCSS.jsx
+++ b/src/MapInteractionCSS.jsx
@@ -5,7 +5,7 @@ import MapInteraction from './MapInteraction';
   This component provides a map like interaction to any content that you place in it. It will let
   the user zoom and pan the children by scaling and translating props.children using css.
 */
-const MapInteractionCSS = (props) => {
+const MapInteractionCSS = React.memo((props) => {
   return (
     <MapInteraction {...props}>
       {
@@ -48,6 +48,6 @@ const MapInteractionCSS = (props) => {
       }
     </MapInteraction>
   );
-};
+});
 
 export default MapInteractionCSS;


### PR DESCRIPTION
I first wanted to appreciate developing such a great module.

To solve [the issue explained here](https://github.com/transcriptic/react-map-interaction/issues/40), I defined a new `props` for the component to check if the user is hovering on an `input` or `textarea`. To do this, one can easily create a `textIsHovered` state in their parent component and use a piece of code like the following one to inform `MapInteraction` not to disable dragging and focusing on `input` and `textarea`s:
```
<ParentComponent
  onMouseOver={(event) => {
    if (
      event.target.tagName.toLowerCase() === "input" ||
      event.target.tagName.toLowerCase() === "textarea" ||
      event.target.className.includes("EditableTextarea")
    ) {
      setTextIsHovered(true);
    } else {
      setTextIsHovered(false);
    }
  }}
>
  <MapInteraction textIsHovered={textIsHovered}>
</ParentComponent>
```
In my own project, this is working very well. Let me know if you have any questions or concerns.