### PR TITLE
Fix webpack 5 case sensitive warning

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
     react: {
       commonjs: "react",
       commonjs2: "react",
-      amd: "React",
+      amd: "react",
       root: "React"
     },
     "prop-types": {


### PR DESCRIPTION
WARNING in ./node_modules/React/index.js
There are multiple modules with names that only differ in casing.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.